### PR TITLE
Reverse order of CHECK_THROW arguments to match the API of UnitTest++

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ void go_to_end_of_earth ()
 
 TEST (EndOfTheEarth)
 {
-  CHECK_THROW (flat_earth_exception, go_to_end_of_earth ());
+  CHECK_THROW (go_to_end_of_earth (), flat_earth_exception);
 }
 
 ````

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -124,10 +124,10 @@ running a test:
 `CHECK_ARRAY2D_CLOSE(expected, actual, rows, columns, tolerance)` Checks that
  two matrices are within the specified tolerance.
  
-`CHECK_THROW(ExceptionType, expression)` Verifies that expression throws an 
+`CHECK_THROW(expression, ExceptionType)` Verifies that expression throws an 
  of the given type.
 
-`CHECK_THROW_EQUAL(ExceptionType, expected, expression)` Verifies that expression
+`CHECK_THROW_EQUAL(expression, expected, ExceptionType)` Verifies that expression
  throws an of the given type and with the expected value.
 
 CHECK_EQUAL and CHECK_THOW_EQUAL macros use a template function UnitTest::CheckEqual()

--- a/docs/main.md
+++ b/docs/main.md
@@ -69,7 +69,7 @@ void go_to_end_of_earth ()
 
 TEST (EndOfTheEarth)
 {
-  CHECK_THROW (flat_earth_exception, go_to_end_of_earth ());
+  CHECK_THROW (go_to_end_of_earth (), flat_earth_exception);
 }
 
 ```

--- a/include/utpp/checks.h
+++ b/include/utpp/checks.h
@@ -314,7 +314,7 @@
 #ifdef CHECK_THROW
 #error Macro CHECK_THROW is already defined
 #endif
-#define CHECK_THROW(except, expr) \
+#define CHECK_THROW(expr, except) \
   do                                                                          \
   {                                                                           \
     bool caught_ = false;                                                     \
@@ -340,7 +340,7 @@
 #ifdef CHECK_THROW_EX
 #error Macro CHECK_THROW_EX is already defined
 #endif
-#define CHECK_THROW_EX(except, expr, ...) \
+#define CHECK_THROW_EX(expr, except, ...) \
   do                                                                          \
   {                                                                           \
     bool caught_ = false;                                                     \
@@ -371,7 +371,7 @@
 #ifdef CHECK_THROW_EQUAL
 #error Macro CHECK_THROW_EQUAL is already defined
 #endif
-#define CHECK_THROW_EQUAL(except, value, expression)                          \
+#define CHECK_THROW_EQUAL(expression, value, except)                          \
   do                                                                          \
   {                                                                           \
     bool caught_ = false;                                                     \
@@ -403,7 +403,7 @@
 #ifdef CHECK_THROW_EQUAL_EX
 #error Macro CHECK_THROW_EQUAL_EX is already defined
 #endif
-#define CHECK_THROW_EQUAL_EX(except, value, expression, ...)                  \
+#define CHECK_THROW_EQUAL_EX(expression, value, except, ...)                  \
   do                                                                          \
   {                                                                           \
     bool caught_ = false;                                                     \

--- a/sample/sample.cpp
+++ b/sample/sample.cpp
@@ -137,22 +137,22 @@ SUITE (EarthSuite)
   // Example of CHECK_THROW macro
   TEST (EndOfTheEarth)
   {
-    CHECK_THROW (flat_earth_exception, go_to_end_of_earth ());
-    CHECK_THROW_EX (flat_earth_exception, planet_name (), "just testing CHECK_THROW_EX macro");
+    CHECK_THROW (go_to_end_of_earth (), flat_earth_exception);
+    CHECK_THROW_EX (planet_name (), flat_earth_exception, "just testing CHECK_THROW_EX macro");
   }
 }
 
 // Example of CHECK_THROW_EQUAL
 TEST (CheckThrowEqual)
 {
-  CHECK_THROW_EQUAL (int, 2, throw_2());
+  CHECK_THROW_EQUAL (throw_2(), 2, int);
 
   int val = 3;
-  CHECK_THROW_EQUAL_EX (int, val, throw_2 (), "Value is %d - This is expected", val);
+  CHECK_THROW_EQUAL_EX (throw_2 (), val, int, "Value is %d - This is expected", val);
 
   //Handling unexpected exceptions - logs an error
   //Shows also how small closures can become arguments to CHECK macros
-  CHECK_THROW (int, []() {throw std::exception{ "Other exception" };}());
+  CHECK_THROW ([]() {throw std::exception{ "Other exception" };}(), int);
 }
 
 
@@ -260,8 +260,8 @@ TEST (Array2D_Close)
 TEST (AnotherException)
 {
   std::vector<int> fibs;
-  CHECK_THROW (std::exception, fibonacci (-1, fibs));
-  CHECK_THROW (std::exception, fibonacci (200, fibs));
+  CHECK_THROW (fibonacci (-1, fibs), std::exception);
+  CHECK_THROW (fibonacci (200, fibs), std::exception);
 }
 
 // Example of a test with a fixture


### PR DESCRIPTION
For consistency, also change the order in CHECK_THROW_EX/EQUAL/EQUAL_EX.

Fixes #2.