### PR TITLE
Calculate tolerance without calling fabs()

### DIFF
--- a/include/utpp/checks.h
+++ b/include/utpp/checks.h
@@ -883,7 +883,7 @@ bool isClose (const expected_T& expected, const actual_T& actual, double toleran
       throw UnitTest::tolerance_not_set ();
     tolerance = UnitTest::default_tolerance;
   }
-  return fabs (actual - expected) <= tolerance;
+  return (actual >= (expected - tolerance)) && (actual <= (expected + tolerance));
 }
 /*!
   Check if two values are closer than specified tolerance. If not, generate a


### PR DESCRIPTION
Implementation now the same as in UnitTest++.

When calling CHECK_CLOSE with int arguments, the call to fabs() may be ambiguous and fails to compile. I.e. the compiler cannot decide whether it should use fabs(float), fabs(long double), or what. (This was encountered on the OpenIndiana platform).