### PR TITLE
Fix warning about unused variable

### DIFF
--- a/include/utpp/reporter_xml.h
+++ b/include/utpp/reporter_xml.h
@@ -114,7 +114,7 @@ int ReporterXml::Summary ()
 #else
   struct tm* timeinfo;
   char buffer[80];
-  time_t t = system_clock::to_time_t (beg_time);
+  time_t t = system_clock::to_time_t (start_time);
   timeinfo = gmtime (&t);
   strftime (buffer, sizeof(buffer), "%F %TZ", timeinfo);
   os << " <start-time>" << buffer << "</start-time>" << std::endl;


### PR DESCRIPTION
The fix, probably, is to use beg_time rather than start_time in both branches of the #if.