### PR TITLE
Improve C++20-compilability for compilers with limited C++20 support

### DIFF
--- a/include/utpp/reporter_xml.h
+++ b/include/utpp/reporter_xml.h
@@ -102,13 +102,13 @@ int ReporterXml::Summary ()
     << " total=\"" << total_test_count << '\"'
     << " failed=\"" << total_failed_count << '\"'
     << " failures=\"" << total_failures_count << '\"' << " duration=\"" << std::fixed << std::setprecision (3)
-#if _MSVC_LANG >= 202002L
+#if UTPP_STD_CHRONO_OSTREAM_AVAILABLE
     << total_time_s << '\"'
 #else
     << total_time_s.count() << "s\""
 #endif
     << '>' << std::endl;
-#if _MSVC_LANG >= 202002L
+#if UTPP_STD_FORMAT_AVAILABLE
   auto start_time_sec = time_point_cast<std::chrono::seconds>(start_time);
   os << " <start-time>" << std::format("{0:%F} {0:%T}Z", start_time_sec) << "</start-time>" << std::endl;
 #else
@@ -164,7 +164,7 @@ int ReporterXml::Summary ()
   }
   if (!suite.empty ())
     os << " </suite>" << std::endl;
-#if _MSVC_LANG >= 202002L
+#if UTPP_STD_FORMAT_AVAILABLE
   os << " <end-time>" << std::format ("{0:%F} {0:%T}Z", end_time) << "</end-time>" << std::endl;
 #else
   t = system_clock::to_time_t (end_time);
@@ -191,7 +191,7 @@ void ReporterXml::BeginTest (const ReporterDeferred::TestResult& result)
 {
   os << "  <test"
     << " name=\"" << result.test_name << "\""
-#if _MSVC_LANG >= 202002L
+#if UTPP_STD_CHRONO_OSTREAM_AVAILABLE
     << " time=\"" << result.test_time << "\"";
 #else
     << " time=\"" << result.test_time.count() << "ms\"";

--- a/include/utpp/utpp.h
+++ b/include/utpp/utpp.h
@@ -45,6 +45,18 @@
 #include <unistd.h>
 #endif
 
+#ifdef __cpp_lib_format
+#define UTPP_STD_FORMAT_AVAILABLE 1
+#else
+#define UTPP_STD_FORMAT_AVAILABLE 0
+#endif
+#if ((_MSVC_LANG >= 202002L && \
+  (!defined(_LIBCPP_VERSION) || _LIBCPP_VERSION >= 160000)))
+#define UTPP_STD_CHRONO_OSTREAM_AVAILABLE 1
+#else
+#define UTPP_STD_CHRONO_OSTREAM_AVAILABLE 0
+#endif
+
 // --------------- Global configuration options -------------------------------
 #define UTPP_VERSION "3.0.1"
 
@@ -858,13 +870,13 @@ void TestSuite::RunCurrentTest (const Inserter* inf)
     std::stringstream stream;
     stream << "Global time constraint failed while running test " << inf->test_name
       << " Expected time <"
-#if _MSVC_LANG >= 202002L
+#if UTPP_STD_CHRONO_OSTREAM_AVAILABLE
       << max_runtime
 #else
       << max_runtime.count () << "ms"
 #endif
       << "; actual = "
-#if _MSVC_LANG >= 202002L
+#if UTPP_STD_CHRONO_OSTREAM_AVAILABLE
       << actual_time;
 #else
       << actual_time.count ();
@@ -994,13 +1006,13 @@ TimeConstraint::~TimeConstraint ()
   {
     std::stringstream stream;
     stream << "Time constraint failed. Expected time <"
-#if _MSVC_LANG >= 202002L
+#if UTPP_STD_CHRONO_OSTREAM_AVAILABLE
       << tmax
 #else
       << tmax.count () << "ms"
 #endif
       << "; actual = "
-#if _MSVC_LANG >= 202002L
+#if UTPP_STD_CHRONO_OSTREAM_AVAILABLE
       << t;
 #else
       << t.count () << "ms";


### PR DESCRIPTION
Some compiler versions (Apple's Clang version 14.0.0, for example) support C++20 to some extent, and set `__cplusplus` accordingly, but do not fully support certain features.

Use `__cpp_lib_format` to check if a fully functional `std::format` is available. Specifically, the previously mentioned compiler lacks something required to format `std::chrono`-related symbols, and compilation fails.

To determine whether `std::chrono` symbols can be passed to an `std::ostream`, check the version of libc++, if using libc++. (In absence of a better check.)