### PR TITLE
Add missing include

### DIFF
--- a/include/utpp/checks.h
+++ b/include/utpp/checks.h
@@ -19,6 +19,7 @@
 #include <string>
 #include <cmath>
 #include <cstring>
+#include <sys/stat.h>
 
 /*!
   \ingroup checks


### PR DESCRIPTION
Fixes this error on MinGW:

```
In file included from ../../../tests/utpp/utpp.h:1231,
                 from ../../../tests/Main.cpp:21:
../../../tests/utpp/checks.h: In function 'bool UnitTest::CheckFileEqual(const std::string&, const std::string&, std::string&)':
../../../tests/utpp/checks.h:1266:15: error: aggregate 'UnitTest::CheckFileEqual(const std::string&, const std::string&, std::string&)::stat st1' has incomplete type and cannot be defined
 1266 |   struct stat st1, st2;
      |               ^~~
```